### PR TITLE
Misc fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+CONTAINER_PATH ?= ferest/etcd-initer
+CONTAINER_VERSION ?= $(shell git describe --tags --always)
+
+build:
+	docker build --no-cache -t "$(CONTAINER_PATH):$(CONTAINER_VERSION)" .
+	docker tag "$(CONTAINER_PATH):$(CONTAINER_VERSION)" "$(CONTAINER_PATH):latest"
+
+push:
+	docker push "$(CONTAINER_PATH):$(CONTAINER_VERSION)"
+	docker push "$(CONTAINER_PATH):latest"
+
+.PHONY: build push

--- a/etcd-init.sh
+++ b/etcd-init.sh
@@ -1,17 +1,37 @@
 #!/bin/sh
 
-for line in $(echo $ETCD_INIT_CLUSTER | tr ',' '\n'); do
-    echo $line | awk  -F'[=/:]' '{print $1,$5}' | {
-        read -r  name myip
-        if ip addr show | grep -q $myip &> /dev/null ; then
-            cat > $ETCD_INIT_ARGSFILE <<EOF
---name $name --initial-advertise-peer-urls http://$myip:$ETCD_INIT_PEER_PORT \
---listen-peer-urls http://$myip:$ETCD_INIT_PEER_PORT \
---advertise-client-urls http://$myip:$ETCD_INIT_LISTEN_PORT \
---listen-client-urls http://$myip:$ETCD_INIT_LISTEN_PORT,http://127.0.0.1:$ETCD_INIT_LISTEN_PORT \
+set -euo pipefail
+
+: ${ETCD_INIT_LISTEN_PROTOCOL:=http}
+: ${ETCD_INIT_LISTEN_PEER_PROTOCOL:=http}
+: ${ETCD_INIT_LISTEN_LOCALHOST_PROTOCOL:="$ETCD_INIT_LISTEN_PROTOCOL"}
+: ${ETCD_INIT_LISTEN_LOCALHOST_PORT:="$ETCD_INIT_LISTEN_PORT"}
+: ${ETCD_INIT_LISTEN_ON_LOCALHOST:=1}
+
+EXTRA_LISTEN=
+if [ "$ETCD_INIT_LISTEN_ON_LOCALHOST" = "1" ]
+then
+    EXTRA_LISTEN=",${ETCD_INIT_LISTEN_LOCALHOST_PROTOCOL}://127.0.0.1:$ETCD_INIT_LISTEN_LOCALHOST_PORT"
+fi
+
+IFS=,
+for LINE in $ETCD_INIT_CLUSTER; do
+    NAME=$(echo "$LINE" | awk -F'[=/:]' '{print $1}')
+    IP=$(echo "$LINE" | awk -F'[=/:]' '{print $5}')
+    if ip addr show | grep -qF "inet $IP/"; then
+        echo "Using IP=$IP, NAME=$NAME."
+        cat > "$ETCD_INIT_ARGSFILE" <<EOF
+--name $NAME \
+--initial-advertise-peer-urls $ETCD_INIT_LISTEN_PEER_PROTOCOL://$IP:$ETCD_INIT_PEER_PORT \
+--listen-peer-urls $ETCD_INIT_LISTEN_PEER_PROTOCOL://$IP:$ETCD_INIT_PEER_PORT \
+--advertise-client-urls $ETCD_INIT_LISTEN_PROTOCOL://$IP:$ETCD_INIT_LISTEN_PORT \
+--listen-client-urls $ETCD_INIT_LISTEN_PROTOCOL://$IP:$ETCD_INIT_LISTEN_PORT$EXTRA_LISTEN \
 --initial-cluster $ETCD_INIT_CLUSTER \
 --data-dir $ETCD_INIT_DATA_DIR
 EOF
-        fi
-    }
+        exit 0
+    fi
 done
+
+echo "Error: Could not find any of my IPs in ETCD_INIT_CLUSTER=$ETCD_INIT_CLUSTER" >&2
+exit 1


### PR DESCRIPTION
Unescaped regex grep without delimiters would match 10.0.0.2 when
the local IP was 10.0.0.20.

Errors and undefined variables should stop the script with an error.

Not finding a match should result in and error that makes sense.

Protocol and localhost listener should be able to be overridden.
The defaults from the previous version are preserved.

Global shell variables should be in uppercase.  Shell variables
should be quoted whenever possible.

Add Makefile.